### PR TITLE
Create UUID+LosslessStringConvertible.swift

### DIFF
--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -31,7 +31,7 @@ public struct Parameters {
     }
     
     /// Grabs the named parameter from the parameter bag, casting it to
-    /// a `LosslessStringConvertible` type.
+    /// a `RouteParameterConvertible` type.
     ///
     /// For example GET /posts/:post_id/comments/:comment_id
     /// would be fetched using:
@@ -40,7 +40,7 @@ public struct Parameters {
     ///     let commentID = parameters.get("comment_id", as: Int.self)
     ///
     public func get<T>(_ name: String, as type: T.Type = T.self) -> T?
-        where T: LosslessStringConvertible
+        where T: RouteParameterConvertible
     {
         return self.get(name).flatMap(T.init)
     }

--- a/Sources/RoutingKit/RouteParameterConvertible.swift
+++ b/Sources/RoutingKit/RouteParameterConvertible.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-extension UUID: LosslessStringConvertible {
+public protocol RouteParameterConvertible: LosslessStringConvertible { }
+
+extension UUID: RouteParameterConvertible {
     
     public init?(_ description: String) {
         self.init(uuidString: description)

--- a/Sources/RoutingKit/UUID+LosslessStringConvertible.swift
+++ b/Sources/RoutingKit/UUID+LosslessStringConvertible.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension UUID: LosslessStringConvertible {
+    
+    public init?(_ description: String) {
+        self.init(uuidString: description)
+    }
+    
+}


### PR DESCRIPTION
we need to make UUID conform to LosslessStringConvertible in order to use it a param