### PR TITLE
add Parameter conformance to RawRepresentable enums

### DIFF
--- a/Sources/Routing/Parameter/Parameter.swift
+++ b/Sources/Routing/Parameter/Parameter.swift
@@ -107,8 +107,25 @@ extension UUID: Parameter {
     }
 }
 
+/// Allows enums defined with raw values to be used as dynamic route parameters.
+/// This allows routes such as
+///
+///     router.get("users", Team.self) { req in
+///         let team = try req.parameters.next(Team.self)
+///         return "user team: \(team)"
+///     }
+///
+/// where `Team` could be an enum of the following
+///
+///     enum Team: String {
+///         case red
+///         case blue
+///     }
+///
+/// this would turn a route into `/users/red` for example.
+
 extension RawRepresentable where Self: Parameter, RawValue: Parameter, RawValue == RawValue.ResolvedParameter {
-    static func resolveParameter(_ parameter: String, on container: Container) throws -> Self {
+    public static func resolveParameter(_ parameter: String, on container: Container) throws -> Self {
         let rawValue = try RawValue.resolveParameter(parameter, on: container)
         guard let value = Self(rawValue: rawValue) else {
             throw RoutingError(identifier: "noMatchingCase", reason: "Could not create value of \(Self.self), string \(parameter) does not match any existing cases.")

--- a/Sources/Routing/Parameter/Parameter.swift
+++ b/Sources/Routing/Parameter/Parameter.swift
@@ -108,10 +108,7 @@ extension UUID: Parameter {
 }
 
 extension RawRepresentable where Self: Parameter, RawValue: Parameter, RawValue == RawValue.ResolvedParameter {
-    static func resolveParameter(
-        _ parameter: String,
-        on container: Container
-        ) throws -> Self {
+    static func resolveParameter(_ parameter: String, on container: Container) throws -> Self {
         let rawValue = try RawValue.resolveParameter(parameter, on: container)
         guard let value = Self(rawValue: rawValue) else {
             throw RoutingError(identifier: "noMatchingCase", reason: "Could not create value of \(Self.self), string \(parameter) does not match any existing cases.")

--- a/Sources/Routing/Parameter/Parameter.swift
+++ b/Sources/Routing/Parameter/Parameter.swift
@@ -107,3 +107,11 @@ extension UUID: Parameter {
     }
 }
 
+extension RawRepresentable: Parameter {
+    static func resolveParameter(_ parameter: String, on container: Container) throws -> Self {
+        guard let value = Self(rawValue: parameter) else {
+            throw FluentError(identifier: "noMatchingCase", reason: "Could not create value of \(Self.self), string \(parameter) does not match any existing cases.")
+        }
+        return value
+    }
+}

--- a/Sources/Routing/Parameter/Parameter.swift
+++ b/Sources/Routing/Parameter/Parameter.swift
@@ -107,10 +107,14 @@ extension UUID: Parameter {
     }
 }
 
-extension RawRepresentable: Parameter {
-    static func resolveParameter(_ parameter: String, on container: Container) throws -> Self {
-        guard let value = Self(rawValue: parameter) else {
-            throw FluentError(identifier: "noMatchingCase", reason: "Could not create value of \(Self.self), string \(parameter) does not match any existing cases.")
+extension RawRepresentable where Self: Parameter, RawValue: Parameter, RawValue == RawValue.ResolvedParameter {
+    static func resolveParameter(
+        _ parameter: String,
+        on container: Container
+        ) throws -> Self {
+        let rawValue = try RawValue.resolveParameter(parameter, on: container)
+        guard let value = Self(rawValue: rawValue) else {
+            throw RoutingError(identifier: "noMatchingCase", reason: "Could not create value of \(Self.self), string \(parameter) does not match any existing cases.")
         }
         return value
     }


### PR DESCRIPTION
Adding conformance to `Parameter` for RawRepresentable enums. 

Looking for input on the following:
- We could change the extension to such that it doesn't conform automatically but you don't have to implement the `resolveParameter` function. Or the way it is implemented now, just conforming to `Parameter`.
- Maybe only have `RawRepresentable`s where their `RawValue` conforms to `Parameter`, conform to `Parameter`

I would like some feedback on this :) Let me know

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
