### PR TITLE
Expose readable path from TrieRouter

### DIFF
--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -19,6 +19,7 @@ final class RouterNode<Output> {
     /// This node's output
     var output: Output?
     
+    /// The human readable path for this node.
     var path: String?
 
     /// Creates a new `RouterNode`.

--- a/Sources/Routing/Routing/RouterNode.swift
+++ b/Sources/Routing/Routing/RouterNode.swift
@@ -18,6 +18,8 @@ final class RouterNode<Output> {
 
     /// This node's output
     var output: Output?
+    
+    var path: String?
 
     /// Creates a new `RouterNode`.
     init(value: Data, output: Output? = nil) {

--- a/Sources/Routing/Routing/TrieRouter.swift
+++ b/Sources/Routing/Routing/TrieRouter.swift
@@ -55,8 +55,9 @@ public final class TrieRouter<Output> {
             }
         }
         current.output = route.output
+        current.path = route.path.readable
     }
-
+    
     /// Routes a `path`, returning the best-matching output and collecting any dynamic parameters.
     ///
     ///     var params = Parameters()
@@ -65,8 +66,8 @@ public final class TrieRouter<Output> {
     /// - parameters:
     ///     - path: Array of `RoutableComponent` to route against.
     ///     - params: A mutable `Parameters` to collect dynamic parameters.
-    /// - returns: Best-matching output for the supplied path.
-    public func route<C>(path: [C], parameters: inout Parameters) -> Output? where C: RoutableComponent {
+    /// - returns: Best-matching output for the supplied path & human readable path if available.
+    public func route<C>(path: [C], parameters: inout Parameters) -> (Output?, String?) where C: RoutableComponent {
         // always start at the root node
         var currentNode: RouterNode = root
 
@@ -102,14 +103,27 @@ public final class TrieRouter<Output> {
             // no constants or dynamic members, check for catchall
             if let catchall = currentNode.catchall {
                 // there is a catchall and it is final, short-circuit to its output
-                return catchall.output
+                return (catchall.output, catchall.path)
             }
 
             // no matches, stop searching
-            return nil
+            return (nil, nil)
         }
 
         // return the currently resolved responder if there hasn't been an early exit.
-        return currentNode.output
+        return (currentNode.output, currentNode.path)
+    }
+
+    /// Routes a `path`, returning the best-matching output and collecting any dynamic parameters.
+    ///
+    ///     var params = Parameters()
+    ///     router.route(path: ["users", "Vapor"], parameters: &params)
+    ///
+    /// - parameters:
+    ///     - path: Array of `RoutableComponent` to route against.
+    ///     - params: A mutable `Parameters` to collect dynamic parameters.
+    /// - returns: Best-matching output for the supplied path.
+    public func route<C>(path: [C], parameters: inout Parameters) -> Output? where C: RoutableComponent {
+        return self.route(path: path, parameters: &parameters).0
     }
 }

--- a/Sources/Routing/Routing/TrieRouter.swift
+++ b/Sources/Routing/Routing/TrieRouter.swift
@@ -67,7 +67,7 @@ public final class TrieRouter<Output> {
     ///     - path: Array of `RoutableComponent` to route against.
     ///     - params: A mutable `Parameters` to collect dynamic parameters.
     /// - returns: Best-matching output for the supplied path & human readable path if available.
-    public func route<C>(path: [C], parameters: inout Parameters) -> (Output?, String?) where C: RoutableComponent {
+    public func getOutputAndPath<C>(for path: [C], parameters: inout Parameters) -> (Output?, String?) where C: RoutableComponent {
         // always start at the root node
         var currentNode: RouterNode = root
 
@@ -124,6 +124,6 @@ public final class TrieRouter<Output> {
     ///     - params: A mutable `Parameters` to collect dynamic parameters.
     /// - returns: Best-matching output for the supplied path.
     public func route<C>(path: [C], parameters: inout Parameters) -> Output? where C: RoutableComponent {
-        return self.route(path: path, parameters: &parameters).0
+        return self.getOutputAndPath(for: path, parameters: &parameters).0
     }
 }

--- a/Tests/RoutingTests/RouterTests.swift
+++ b/Tests/RoutingTests/RouterTests.swift
@@ -136,7 +136,7 @@ class RouterTests: XCTestCase {
         router.register(route: Route(path: [.constant("users"), .parameter("user_id")], output: "show_user"))
 
         var params = Parameters()
-        let _: String? = router.route(path: ["users", "42"], parameters: &params)
+        _ = router.route(path: ["users", "42"], parameters: &params)
         print(params)
     }
 

--- a/Tests/RoutingTests/RouterTests.swift
+++ b/Tests/RoutingTests/RouterTests.swift
@@ -136,7 +136,7 @@ class RouterTests: XCTestCase {
         router.register(route: Route(path: [.constant("users"), .parameter("user_id")], output: "show_user"))
 
         var params = Parameters()
-        _ = router.route(path: ["users", "42"], parameters: &params)
+        let _: String? = router.route(path: ["users", "42"], parameters: &params)
         print(params)
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

For http://github.com/vapor-community/VaporMonitoring we would like to be able to get a hold of the `[PathComponent].readable` to group our metrics by. This PR aims to expose this from `TrieRouter` so we can pick it up in vapor/vapor

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
