### PR TITLE
Use PathComponents as parameters

### DIFF
--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -26,10 +26,10 @@ public struct Parameters {
     ///     let postID = parameters.get("post_id")
     ///     let commentID = parameters.get("comment_id")
     ///
-    public func get(_ name: String) -> String? {
-        return self.values[name]
+    public func get(_ parameter: PathComponent) -> String? {
+        guard case .parameter(let name) = parameter else { return nil }
+        return get(name)
     }
-    
     /// Grabs the named parameter from the parameter bag, casting it to
     /// a `LosslessStringConvertible` type.
     ///
@@ -39,12 +39,12 @@ public struct Parameters {
     ///     let postID = parameters.get("post_id", as: Int.self)
     ///     let commentID = parameters.get("comment_id", as: Int.self)
     ///
-    public func get<T>(_ name: String, as type: T.Type = T.self) -> T?
+    public func get<T>(_ parameter: PathComponent, as type: T.Type = T.self) -> T?
         where T: LosslessStringConvertible
     {
-        return self.get(name).flatMap(T.init)
+        get(parameter).flatMap(T.init)
     }
-    
+
     /// Adds a new parameter value to the bag.
     ///
     /// - note: The value will be percent-decoded.

--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -18,21 +18,21 @@ public struct Parameters {
         values = [:]
     }
 
-    /// Grabs the named parameter from the parameter bag.
+    /// Grabs the parameter, supplied as a `PathComponent.parameter`, from the parameter bag.
     ///
     /// For example GET /posts/:post_id/comments/:comment_id
     /// would be fetched using:
     ///
-    ///     let postID = parameters.get("post_id")
-    ///     let commentID = parameters.get("comment_id")
+    ///     let postID = parameters.get(.postId)
+    ///     let commentID = parameters.get(.commentId)
     ///
     public func get(_ parameter: PathComponent) -> String? {
-        guard case .parameter(let name) = parameter else { return nil }
+        if case .parameter(let name) = parameter { return nil }
         return get(name)
     }
 
-    /// Grabs the named parameter from the parameter bag, casting it to
-    /// a `LosslessStringConvertible` type.
+    /// Grabs the parameter, supplied as a `PathComponent.parameter`, from the parameter bag,
+    /// casting it to a `LosslessStringConvertible` type.
     ///
     /// For example GET /posts/:post_id/comments/:comment_id
     /// would be fetched using:
@@ -51,8 +51,8 @@ public struct Parameters {
     /// For example GET /posts/:post_id/comments/:comment_id
     /// would be fetched using:
     ///
-    ///     let postID = parameters.get(.postId)
-    ///     let commentID = parameters.get(.commentId)
+    ///     let postID = parameters.get("post_id")
+    ///     let commentID = parameters.get("comment_id")
     ///
     public func get(_ name: String) -> String? {
         values[name]

--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -27,7 +27,7 @@ public struct Parameters {
     ///     let commentID = parameters.get(.commentId)
     ///
     public func get(_ parameter: PathComponent) -> String? {
-        if case .parameter(let name) = parameter { return nil }
+        guard case .parameter(let name) = parameter else { return nil }
         return get(name)
     }
 

--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -28,21 +28,34 @@ public struct Parameters {
     ///
     public func get(_ parameter: PathComponent) -> String? {
         guard case .parameter(let name) = parameter else { return nil }
-        return values[name]
+        return get(name)
     }
+
     /// Grabs the named parameter from the parameter bag, casting it to
     /// a `LosslessStringConvertible` type.
     ///
     /// For example GET /posts/:post_id/comments/:comment_id
     /// would be fetched using:
     ///
-    ///     let postID = parameters.get("post_id", as: Int.self)
-    ///     let commentID = parameters.get("comment_id", as: Int.self)
+    ///     let postID = parameters.get(.postId, as: Int.self)
+    ///     let commentID = parameters.get(.commentId, as: Int.self)
     ///
     public func get<T>(_ parameter: PathComponent, as type: T.Type = T.self) -> T?
         where T: LosslessStringConvertible
     {
         get(parameter).flatMap(T.init)
+    }
+
+    /// Grabs the named parameter from the parameter bag.
+    ///
+    /// For example GET /posts/:post_id/comments/:comment_id
+    /// would be fetched using:
+    ///
+    ///     let postID = parameters.get(.postId)
+    ///     let commentID = parameters.get(.commentId)
+    ///
+    public func get(_ name: String) -> String? {
+        values[name]
     }
 
     /// Adds a new parameter value to the bag.
@@ -53,6 +66,6 @@ public struct Parameters {
     ///     - name: Unique parameter name
     ///     - value: Value (percent-encoded if necessary)
     public mutating func set(_ name: String, to value: String?) {
-        self.values[name] = value?.removingPercentEncoding
+        values[name] = value?.removingPercentEncoding
     }
 }

--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -28,7 +28,7 @@ public struct Parameters {
     ///
     public func get(_ parameter: PathComponent) -> String? {
         guard case .parameter(let name) = parameter else { return nil }
-        return get(name)
+        return values[name]
     }
     /// Grabs the named parameter from the parameter bag, casting it to
     /// a `LosslessStringConvertible` type.


### PR DESCRIPTION
`Parameter` and `PathComponent`s are very clever, so it's a shame we need to resort to strings to use them. With this PR you can define things like:

```Swift
// In routes.swift for example
extension PathComponent {
    static let api: Self = "api"
    static let publicApi: Self = "public-api"
}

// In TodoController.swift
extension PathComponent {
    static let todo: Self = "todo"
}

fileprivate extension PathComponent {
    static let todoId: Self = .parameter("todoId")
}
```

and then 

```Swift
func boot(routes: RoutesBuilder) throws {
    let tokenProtected = routes.grouped(.api, .todo).grouped(UserToken.authenticator().middleware(), User.guardMiddleware())
    tokenProtected.get(.todoId, use: getHandler)
}

func getHandler(req: Request) throws -> EventLoopFuture<Todo> {
    Todo.find(req.parameters.get(.todoId), on: req.db)
        .unwrap(or: Abort(.notFound))
}
```

But because of `StringLiteralConvertible` you can also still do this if you really want to:

```Swift
func getHandler(req: Request) throws -> EventLoopFuture<Todo> {
    Todo.find(req.parameters.get("todoId"), on: req.db)
        .unwrap(or: Abort(.notFound))
}
```

### Checklist

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.
