### PR TITLE
Type Safe Parameters

### DIFF
--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -7,6 +7,7 @@ import Foundation
 ///
 ///     let postID = parameters.get("post_id")
 ///
+@dynamicMemberLookup
 public struct Parameters {
     /// Internal storage.
     private var values: [String: String]
@@ -16,6 +17,12 @@ public struct Parameters {
     /// Pass this into the `Router.route(path:parameters:)` method to fill with values.
     public init() {
         values = [:]
+    }
+
+    public subscript<Value>(dynamicMember paramater: KeyPath<PathComponent.Type, Parameter<Value>>) -> Value? {
+        guard let raw = self.values[PathComponent.self[keyPath: paramater].name] else { return nil }
+        guard let value = Value(raw) else { return nil }
+        return value
     }
 
     /// Grabs the named parameter from the parameter bag.
@@ -54,5 +61,16 @@ public struct Parameters {
     ///     - value: Value (percent-encoded if necessary)
     public mutating func set(_ name: String, to value: String?) {
         self.values[name] = value?.removingPercentEncoding
+    }
+}
+
+@propertyWrapper public struct Parameter<Value> where Value: LosslessStringConvertible {
+    public let name: String
+
+    @available(*, unavailable, message: "This property never contains a value and will always crash if you try to access it.")
+    public var wrappedValue: Value { fatalError("You shouldn't ever call this ") }
+
+    public init(name: String) {
+        self.name = name
     }
 }

--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -1,5 +1,7 @@
 /// A single path component of a `Route`. An array of these components describes
 /// a route's path, including which parts are constant and which parts are dynamic.
+
+@dynamicMemberLookup
 public enum PathComponent: ExpressibleByStringLiteral, CustomStringConvertible {
     /// A normal, constant path component.
     case constant(String)
@@ -25,6 +27,10 @@ public enum PathComponent: ExpressibleByStringLiteral, CustomStringConvertible {
     ///
     /// Represented as `**`
     case catchall
+
+    public static subscript<Value>(dynamicMember parameter: KeyPath<PathComponent.Type, Parameter<Value>>) -> PathComponent {
+        return .parameter(PathComponent.self[keyPath: parameter].name)
+    }
 
     /// `ExpressibleByStringLiteral` conformance.
     public init(stringLiteral value: String) {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

This adds a type-safe API for routing parameters. In an extension of `PathComponent`, you can define a static stored property with the `Parameter` property wrapper, and then use the wrapper property as both a `PathComponent` in the route path and as a property on the `Parameters` type.

```swift
router.get("users", .$user) { request in
    return request.parameters.$user
}

extension PathComponent {
    @Parameter(name: "user") static var user: UUID
}
```

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [ ] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
