### PR TITLE
Fix String description of the router and add tests

### DIFF
--- a/Sources/RoutingKit/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter.swift
@@ -203,30 +203,34 @@ extension TrieRouter {
         }
         
         var description: String {
+            self.subpathDescriptions.joined(separator: "\n")
+        }
+        
+        var subpathDescriptions: [String] {
             var desc: [String] = []
             for (name, constant) in self.constants {
                 desc.append("→ \(name)")
-                desc += constant.description.indentSliced
+                desc += constant.subpathDescriptions.indented()
             }
             if let (name, parameter) = self.parameter {
                 desc.append("→ :\(name)")
-                desc += parameter.description.indentSliced
+                desc += parameter.subpathDescriptions.indented()
             }
             if let anything = self.anything {
                 desc.append("→ *")
-                desc += anything.description.indentSliced
+                desc += anything.subpathDescriptions.indented()
             }
             if let catchall = self.catchall {
                 desc.append("→ **")
-                desc += catchall.description.indentSliced
+                desc += catchall.subpathDescriptions.indented()
             }
-            return desc.joined(separator: "\n")
+            return desc
         }
     }
 }
 
-private extension String {
-    var indentSliced: [String] {
-        self.split(separator: "\n").map { "  " + $0 }
+private extension Array where Element == String {
+    func indented() -> [String] {
+        return self.map { "  " + $0 }
     }
 }

--- a/Sources/RoutingKit/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter.swift
@@ -206,19 +206,19 @@ extension TrieRouter {
             var desc: [String] = []
             if let (name, parameter) = self.parameter {
                 desc.append("→ :\(name)")
-                desc.append(parameter.description.indented())
+                desc += parameter.description.indentSliced
             }
             if let catchall = self.catchall {
                 desc.append("→ **")
-                desc.append(catchall.description.indented())
+                desc += catchall.description.indentSliced
             }
             if let anything = self.anything {
                 desc.append("→ *")
-                desc.append(anything.description.indented())
+                desc += anything.description.indentSliced
             }
             for (name, constant) in self.constants {
                 desc.append("→ \(name)")
-                desc.append(constant.description.indented())
+                desc += constant.description.indentSliced
             }
             return desc.joined(separator: "\n")
         }
@@ -226,9 +226,7 @@ extension TrieRouter {
 }
 
 private extension String {
-    func indented() -> String {
-        return self.split(separator: "\n").map { line in
-            return "  " + line
-        }.joined(separator: "\n")
+    var indentSliced: [String] {
+        self.split(separator: "\n").map { "  " + $0 }
     }
 }

--- a/Sources/RoutingKit/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter.swift
@@ -204,21 +204,21 @@ extension TrieRouter {
         
         var description: String {
             var desc: [String] = []
+            for (name, constant) in self.constants {
+                desc.append("→ \(name)")
+                desc += constant.description.indentSliced
+            }
             if let (name, parameter) = self.parameter {
                 desc.append("→ :\(name)")
                 desc += parameter.description.indentSliced
-            }
-            if let catchall = self.catchall {
-                desc.append("→ **")
-                desc += catchall.description.indentSliced
             }
             if let anything = self.anything {
                 desc.append("→ *")
                 desc += anything.description.indentSliced
             }
-            for (name, constant) in self.constants {
-                desc.append("→ \(name)")
-                desc += constant.description.indentSliced
+            if let catchall = self.catchall {
+                desc.append("→ **")
+                desc += catchall.description.indentSliced
             }
             return desc.joined(separator: "\n")
         }

--- a/Sources/RoutingKit/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter.swift
@@ -205,15 +205,15 @@ extension TrieRouter {
         var description: String {
             var desc: [String] = []
             if let (name, parameter) = self.parameter {
-                desc.append("→ \(name)")
+                desc.append("→ :\(name)")
                 desc.append(parameter.description.indented())
             }
             if let catchall = self.catchall {
-                desc.append("→ *")
+                desc.append("→ **")
                 desc.append(catchall.description.indented())
             }
             if let anything = self.anything {
-                desc.append("→ :")
+                desc.append("→ *")
                 desc.append(anything.description.indented())
             }
             for (name, constant) in self.constants {

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -127,4 +127,32 @@ final class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["v1", "test", "foo"], parameters: &params), "b")
         XCTAssertEqual(router.route(path: ["v1", "foo"], parameters: &params), "c")
     }
+    
+    func testRouterDescription() throws {
+        // Use simple routing to eliminate the impact of registration order
+        let constA: PathComponent = "a"
+        let constOne: PathComponent = "1"
+        let paramOne: PathComponent = .parameter("1")
+        let anything: PathComponent = .anything
+        let catchall: PathComponent = .catchall
+        let router = TrieRouter<Int>()
+        router.register(0, at: [constA, anything])
+        router.register(1, at: [constA, constOne, catchall])
+        router.register(2, at: [constA, constOne, anything])
+        router.register(3, at: [anything, constA, paramOne])
+        router.register(4, at: [catchall])
+        // Manually build description
+        let desc = """
+            → \(constA)
+              → \(constOne)
+                → \(anything)
+                → \(catchall)
+              → \(anything)
+            → \(anything)
+              → \(constA)
+                → \(paramOne)
+            → \(catchall)
+            """
+        XCTAssertEqual(router.description, desc)
+    }
 }

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -155,4 +155,18 @@ final class RouterTests: XCTestCase {
             """
         XCTAssertEqual(router.description, desc)
     }
+    
+    func testPathComponentDescription() throws {
+        let paths = [
+            "aaaaa/bbbb/ccc/dd",
+            "123/:45/6/789",
+            "123/**",
+            "*/*/*/**",
+            ":12/12/*"
+        ]
+        for path in paths {
+            XCTAssertEqual(path.pathComponents.string, path)
+            XCTAssertEqual(("/" + path).pathComponents.string, path)
+        }
+    }
 }

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -14,7 +14,7 @@ final class RouterTests: XCTestCase {
         let router = TrieRouter<Int>()
         router.register(42, at: [.constant("path"), .constant("TO"), .constant("fOo")])
         var params = Parameters()
-        XCTAssertEqual(router.route(path: ["PATH", "tO", "FOo"], parameters: &params), nil)
+        XCTAssertNil(router.route(path: ["PATH", "tO", "FOo"], parameters: &params))
         XCTAssertEqual(router.route(path: ["path", "TO", "fOo"], parameters: &params), 42)
     }
     


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Fixes `TrieRouter.Node.description` (#93): 
- To match `PathComponent`'s `stringLiteral` expression,
- To match the routing strategy of `TrieRouter`,

And adds tests for `description`s (#93).

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
