### PR TITLE
Add access to components matched by catchall ('**')

### DIFF
--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -10,12 +10,14 @@ import Foundation
 public struct Parameters {
     /// Internal storage.
     private var values: [String: String]
+    private var catchallValues: [String]
 
     /// Creates a new `Parameters`.
     ///
     /// Pass this into the `Router.route(path:parameters:)` method to fill with values.
     public init() {
         self.values = [:]
+        self.catchallValues = []
     }
 
     /// Grabs the named parameter from the parameter bag.
@@ -54,5 +56,17 @@ public struct Parameters {
     ///     - value: Value (percent-encoded if necessary)
     public mutating func set(_ name: String, to value: String?) {
         self.values[name] = value?.removingPercentEncoding
+    }
+    
+    /// Store and fetch `catchall` matches in the bag.
+    ///
+    /// - note: The value will be percent-decoded.
+    public var catchall: [String] {
+        get {
+            self.catchallValues
+        }
+        set {
+            self.catchallValues = newValue.map { $0.removingPercentEncoding ?? $0 }
+        }
     }
 }

--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -23,6 +23,8 @@ public enum PathComponent: ExpressibleByStringLiteral, CustomStringConvertible {
     /// Catch alls have the lowest precedence, and will only be matched
     /// if no more specific path components are found.
     ///
+    /// The matched subpath will be stored into `Parameters.catchall`.
+    ///
     /// Represented as `**`
     case catchall
 

--- a/Sources/RoutingKit/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter.swift
@@ -70,17 +70,17 @@ public final class TrieRouter<Output>: Router, CustomStringConvertible {
         
         let isCaseInsensitive = self.options.contains(.caseInsensitive)
 
-        var currentCatchall: Node?
+        var currentCatchall: (Node, [String])?
 
         // traverse the string path supplied
-        search: for path in path {
+        search: for (index, slice) in path.enumerated() {
             // store catchall in case search hits dead end
             if let catchall = currentNode.catchall {
-                currentCatchall = catchall
+                currentCatchall = (catchall, [String](path.dropFirst(index)))
             }
 
             // check the constants first
-            if let constant = currentNode.constants[isCaseInsensitive ? path.lowercased() : path] {
+            if let constant = currentNode.constants[isCaseInsensitive ? slice.lowercased() : slice] {
                 currentNode = constant
                 continue search
             }
@@ -89,7 +89,7 @@ public final class TrieRouter<Output>: Router, CustomStringConvertible {
             if let (name, parameter) = currentNode.parameter {
                 // if no constant routes were found that match the path, but
                 // a dynamic parameter child was found, we can use it
-                parameters.set(name, to: path)
+                parameters.set(name, to: slice)
                 currentNode = parameter
                 continue search
             }
@@ -101,8 +101,9 @@ public final class TrieRouter<Output>: Router, CustomStringConvertible {
             }
 
             // no matches, stop searching
-            if let catchall = currentCatchall {
+            if let (catchall, matched) = currentCatchall {
                 // fallback to catchall output if we have one
+                parameters.catchall = matched
                 return catchall.output
             } else {
                 return nil
@@ -112,8 +113,9 @@ public final class TrieRouter<Output>: Router, CustomStringConvertible {
         if let output = currentNode.output {
             // return the currently resolved responder if there hasn't been an early exit.
             return output
-        } else if let catchall = currentCatchall {
+        } else if let (catchall, matched) = currentCatchall {
             // fallback to catchall output if we have one
+            parameters.catchall = matched
             return catchall.output
         } else {
             // current node has no output and there was not catchall

--- a/Sources/RoutingKit/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter.swift
@@ -101,9 +101,9 @@ public final class TrieRouter<Output>: Router, CustomStringConvertible {
             }
 
             // no matches, stop searching
-            if let (catchall, matched) = currentCatchall {
+            if let (catchall, subpaths) = currentCatchall {
                 // fallback to catchall output if we have one
-                parameters.catchall = matched
+                parameters.setCatchall(matched: subpaths)
                 return catchall.output
             } else {
                 return nil
@@ -113,9 +113,9 @@ public final class TrieRouter<Output>: Router, CustomStringConvertible {
         if let output = currentNode.output {
             // return the currently resolved responder if there hasn't been an early exit.
             return output
-        } else if let (catchall, matched) = currentCatchall {
+        } else if let (catchall, subpaths) = currentCatchall {
             // fallback to catchall output if we have one
-            parameters.catchall = matched
+            parameters.setCatchall(matched: subpaths)
             return catchall.output
         } else {
             // current node has no output and there was not catchall

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -127,4 +127,16 @@ final class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["v1", "test", "foo"], parameters: &params), "b")
         XCTAssertEqual(router.route(path: ["v1", "foo"], parameters: &params), "c")
     }
+    
+    func testCatchallValue() throws {
+        let router = TrieRouter<Int>()
+        router.register(42, at: ["users", ":user", "**"])
+        router.register(24, at: ["users", "**"])
+
+        var params = Parameters()
+        XCTAssertEqual(router.route(path: ["users", "stevapple"], parameters: &params), 24)
+        XCTAssertEqual(params.catchall, ["stevapple"])
+        XCTAssertEqual(router.route(path: ["users", "stevapple", "posts", "2"], parameters: &params), 42)
+        XCTAssertEqual(params.catchall, ["posts", "2"])
+    }
 }

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -102,7 +102,7 @@ final class RouterTests: XCTestCase {
     }
 
     // https://github.com/vapor/routing-kit/issues/74
-    func testCatchAllNested() throws {
+    func testCatchallNested() throws {
         let router = TrieRouter(String.self)
         router.register("/**", at: [.catchall])
         router.register("/a/**", at: ["a", .catchall])
@@ -117,7 +117,7 @@ final class RouterTests: XCTestCase {
         XCTAssertEqual(router.route(path: ["b", "c", "d", "e"], parameters: &params), "/**")
     }
 
-    func testCatchAllPrecedence() throws {
+    func testCatchallPrecedence() throws {
         let router = TrieRouter(String.self)
         router.register("a", at: ["v1", "test"])
         router.register("b", at: ["v1", .catchall])
@@ -134,9 +134,11 @@ final class RouterTests: XCTestCase {
         router.register(24, at: ["users", "**"])
 
         var params = Parameters()
+        XCTAssertNil(router.route(path: ["users"], parameters: &params))
+        XCTAssertEqual(params.getCatchall().count, 0)
         XCTAssertEqual(router.route(path: ["users", "stevapple"], parameters: &params), 24)
-        XCTAssertEqual(params.catchall, ["stevapple"])
+        XCTAssertEqual(params.getCatchall(), ["stevapple"])
         XCTAssertEqual(router.route(path: ["users", "stevapple", "posts", "2"], parameters: &params), 42)
-        XCTAssertEqual(params.catchall, ["posts", "2"])
+        XCTAssertEqual(params.getCatchall(), ["posts", "2"])
     }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Allows using `Parameters.getCatchall()` to get the components matched by catchall (`**`) (#94).

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
