### PR TITLE
Add .root path helper.

### DIFF
--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -71,4 +71,7 @@ extension Array where Element == PathComponent {
     public var string: String {
         return self.map(\.description).joined(separator: "/")
     }
+
+    /// The root path.
+    public static let root: [Element] = [.constant("")]
 }

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -183,4 +183,11 @@ final class RouterTests: XCTestCase {
             XCTAssertEqual(("/" + path).pathComponents.string, path)
         }
     }
+
+    func testRootPathComponent() {
+        let router = TrieRouter(String.self)
+        router.register("root", at: .root)
+        var params = Parameters()
+        XCTAssertEqual(router.route(path: [""], parameters: &params), "root")
+    }
 }


### PR DESCRIPTION
Currently an empty string is used to define the root path. This change attempts to make this a little more obvious by introducing a `.root` helper.

A root route can now be defined as:

```swift
let homeController = HomeController()
app.get(.root, use: homeController.home)
```
