### PR TITLE
Add support for string interpolation to PathComponent

### DIFF
--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -1,6 +1,6 @@
 /// A single path component of a `Route`. An array of these components describes
 /// a route's path, including which parts are constant and which parts are dynamic.
-public enum PathComponent: ExpressibleByStringLiteral, CustomStringConvertible {
+public enum PathComponent: ExpressibleByStringInterpolation, CustomStringConvertible {
     /// A normal, constant path component.
     case constant(String)
 

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -183,4 +183,83 @@ final class RouterTests: XCTestCase {
             XCTAssertEqual(("/" + path).pathComponents.string, path)
         }
     }
+    
+    func testPathComponentInterpolation() throws {
+        do {
+            let pathComponentLiteral: PathComponent = "path"
+            switch pathComponentLiteral {
+            case .constant(let value):
+                XCTAssertEqual(value, "path")
+            default:
+                XCTFail("pathComponentLiteral \(pathComponentLiteral) is not .constant(\"path\")")
+            }
+        }
+        do {
+            let pathComponentLiteral: PathComponent = ":path"
+            switch pathComponentLiteral {
+            case .parameter(let value):
+                XCTAssertEqual(value, "path")
+            default:
+                XCTFail("pathComponentLiteral \(pathComponentLiteral) is not .parameter(\"path\")")
+            }
+        }
+        do {
+            let pathComponentLiteral: PathComponent = "*"
+            switch pathComponentLiteral {
+            case .anything:
+                break
+            default:
+                XCTFail("pathComponentLiteral \(pathComponentLiteral) is not .anything")
+            }
+        }
+        do {
+            let pathComponentLiteral: PathComponent = "**"
+            switch pathComponentLiteral {
+            case .catchall:
+                break
+            default:
+                XCTFail("pathComponentLiteral \(pathComponentLiteral) is not .catchall")
+            }
+        }
+        do {
+            let constant = "foo"
+            let pathComponentInterpolation: PathComponent = "\(constant)"
+            switch pathComponentInterpolation {
+            case .constant(let value):
+                XCTAssertEqual(value, "foo")
+            default:
+                XCTFail("pathComponentInterpolation \(pathComponentInterpolation) is not .constant(\"foo\")")
+            }
+        }
+        do {
+            let parameter = "foo"
+            let pathComponentInterpolation: PathComponent = ":\(parameter)"
+            switch pathComponentInterpolation {
+            case .parameter(let value):
+                XCTAssertEqual(value, "foo")
+            default:
+                XCTFail("pathComponentInterpolation \(pathComponentInterpolation) is not .parameter(\"foo\")")
+            }
+        }
+        do {
+            let anything = "*"
+            let pathComponentInterpolation: PathComponent = "\(anything)"
+            switch pathComponentInterpolation {
+            case .anything:
+                break
+            default:
+                XCTFail("pathComponentInterpolation \(pathComponentInterpolation) is not .anything")
+            }
+        }
+        do {
+            let catchall = "**"
+            let pathComponentInterpolation: PathComponent = "\(catchall)"
+            switch pathComponentInterpolation {
+            case .catchall:
+                break
+            default:
+                XCTFail("pathComponentInterpolation \(pathComponentInterpolation) is not .catchall")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Enables call sites that use `PathComponent`s to allow for string literals that make use of interpolation (#101).

In Vapor, this enables constants and other variables to be used in routes:
```swift
let api = app.grouped("version-\(Constants.apiVersion)")
```