### PR TITLE
Clarify "same route with different parameter names" error message

### DIFF
--- a/.github/workflows/main-codecov.yml
+++ b/.github/workflows/main-codecov.yml
@@ -1,0 +1,9 @@
+name: Update code coverage baselines
+on:
+  push: { branches: [ main ] }
+jobs:
+  update-main-codecov:
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+    with:
+      with_coverage: true
+      with_tsan: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,29 +1,35 @@
 name: test
 on:
-- pull_request
+  pull_request:
+  push: 
+    branches: 
+      - main
+env:
+  LOG_LEVEL: info
+  SWIFT_DETERMINISTIC_HASHING: 1
+
 jobs:
-  routing-kit_xenial:
-    container: 
-      image: vapor/swift:5.2-xenial
+
+  unit-tests:
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+    with:
+      with_coverage: true
+      with_tsan: true
+  
+  upstream-check:
     runs-on: ubuntu-latest
+    container: swift:5.5-focal
     steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
-  routing-kit_bionic:
-    container: 
-      image: vapor/swift:5.2-bionic
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
-  vapor:
-    container: 
-      image: vapor/swift:5.2
-    runs-on: ubuntu-latest
-    steps:
-    - run: git clone -b main https://github.com/vapor/vapor.git
-      working-directory: ./
-    - run: swift package edit routing-kit --revision ${{ github.sha }}
-      working-directory: ./vapor
-    - run: swift test --enable-test-discovery --sanitize=thread
-      working-directory: ./vapor
+      - name: Check out self
+        uses: actions/checkout@v2
+        with:
+          path: routing-kit
+      - name: Check out Vapor
+        uses: actions/checkout@v2
+        with:
+          repository: vapor/vapor
+          path: vapor
+      - name: Use local package
+        run: swift package --package-path vapor edit routing-kit --path routing-kit
+      - name: Run tests
+        run: swift test --package-path vapor --enable-test-discovery

--- a/Sources/RoutingKit/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter.swift
@@ -212,7 +212,7 @@ extension TrieRouter {
 
                 if let wildcard = self.wildcard {
                     if let existingName = self.wildcard?.parameter {
-                        assert(existingName == name, "Route parameter name mis-match \(existingName) != \(name)")
+                        precondition(existingName == name, "It is not possible to have two routes with the same prefix but different parameter names, even if the trailing path components differ (tried to add route with \(name) that collides with \(existingName)).")
                     } else {
                         wildcard.setParameterName(name)
                     }


### PR DESCRIPTION
An attempt to improve the error message for this unusual case.

Also ensures the error appears in release builds.