### PR TITLE
Update Supported Swift Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   
   upstream-check:
     runs-on: ubuntu-latest
-    container: swift:5.5-focal
+    container: swift:5.6-focal
     steps:
       - name: Check out self
         uses: actions/checkout@v2
@@ -32,4 +32,4 @@ jobs:
       - name: Use local package
         run: swift package --package-path vapor edit routing-kit --path routing-kit
       - name: Run tests
-        run: swift test --package-path vapor --enable-test-discovery
+        run: swift test --package-path vapor

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)