### PR TITLE
Swift 5.6 and Sendable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   
   upstream-check:
     runs-on: ubuntu-latest
-    container: swift:5.7-jammy
+    container: swift:5.8-jammy
     steps:
       - name: Check out self
         uses: actions/checkout@v3

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5.2
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(

--- a/Sources/RoutingKit/Parameters.swift
+++ b/Sources/RoutingKit/Parameters.swift
@@ -8,7 +8,7 @@ import Logging
 ///
 ///     let postID = parameters.get("post_id")
 ///
-public struct Parameters {
+public struct Parameters: Sendable {
     /// Internal storage.
     private var values: [String: String]
     private var catchall: Catchall

--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -1,6 +1,6 @@
 /// A single path component of a `Route`. An array of these components describes
 /// a route's path, including which parts are constant and which parts are dynamic.
-public enum PathComponent: ExpressibleByStringInterpolation, CustomStringConvertible {
+public enum PathComponent: ExpressibleByStringInterpolation, CustomStringConvertible, Sendable {
     /// A normal, constant path component.
     case constant(String)
 


### PR DESCRIPTION
Updates RoutingKit to set Swift 5.6 as the minimum Swift version supported, to bring it in line with the rest of Vapor's packages.

Adds `Sendable` conformances where it makes sense as required by Vapor.