### PR TITLE
Conform PathComponent to Hashable and Equatable

### DIFF
--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -73,4 +73,4 @@ extension Sequence where Element == PathComponent {
     }
 }
 
-extension PathComponent: Equatable {}
+extension PathComponent: Hashable {}

--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -1,6 +1,6 @@
 /// A single path component of a `Route`. An array of these components describes
 /// a route's path, including which parts are constant and which parts are dynamic.
-public enum PathComponent: ExpressibleByStringInterpolation, CustomStringConvertible, Sendable {
+public enum PathComponent: ExpressibleByStringInterpolation, CustomStringConvertible, Sendable, Hashable {
     /// A normal, constant path component.
     case constant(String)
 
@@ -73,4 +73,3 @@ extension Sequence where Element == PathComponent {
     }
 }
 
-extension PathComponent: Hashable {}

--- a/Sources/RoutingKit/PathComponent.swift
+++ b/Sources/RoutingKit/PathComponent.swift
@@ -72,3 +72,5 @@ extension Sequence where Element == PathComponent {
         return self.map(\.description).joined(separator: "/")
     }
 }
+
+extension PathComponent: Equatable {}


### PR DESCRIPTION
Conforms `PathComponent` to Equatable. Related to [this PR](https://github.com/swift-server/swift-openapi-vapor/pull/13#issuecomment-1841643073)
