### PR TITLE
Allow empty paths when `.catchall`ing

### DIFF
--- a/Sources/RoutingKit/TrieRouter/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter/TrieRouter.swift
@@ -95,7 +95,7 @@ public final class TrieRouter<Output: Sendable>: Router, Sendable, CustomStringC
         } else if let (catchall, subpaths) = currentCatchall {
             parameters.setCatchall(matched: subpaths)
             return catchall.output
-        } else if let catchall = currentNode.catchall {
+        } else if path.isEmpty, let catchall = currentNode.catchall {
             parameters.setCatchall(matched: [])
             return catchall.output
         } else {

--- a/Sources/RoutingKit/TrieRouter/TrieRouter.swift
+++ b/Sources/RoutingKit/TrieRouter/TrieRouter.swift
@@ -95,6 +95,9 @@ public final class TrieRouter<Output: Sendable>: Router, Sendable, CustomStringC
         } else if let (catchall, subpaths) = currentCatchall {
             parameters.setCatchall(matched: subpaths)
             return catchall.output
+        } else if let catchall = currentNode.catchall {
+            parameters.setCatchall(matched: [])
+            return catchall.output
         } else {
             return nil
         }

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -382,4 +382,14 @@ struct RouterTests {
         p = Parameters()
         #expect(r.route(path: ["y", "file.md"], parameters: &p) == 1)
     }
+
+    @Test
+    func emptyCatchall() throws {
+        var b = TrieRouterBuilder<Int>()
+        b.register(1, at: [.catchall])
+        let r = b.build()
+
+        var p = Parameters()
+        #expect(r.route(path: [], parameters: &p) == 1)
+    }
 }

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -383,7 +383,7 @@ struct RouterTests {
         #expect(r.route(path: ["y", "file.md"], parameters: &p) == 1)
     }
 
-    @Test
+    @Test(.bug("https://github.com/vapor/routing-kit/issues/147"))
     func emptyCatchall() throws {
         var b = TrieRouterBuilder<Int>()
         b.register(1, at: [.catchall])

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -383,7 +383,7 @@ struct RouterTests {
         #expect(r.route(path: ["y", "file.md"], parameters: &p) == 1)
     }
 
-    @Test(.bug("https://github.com/vapor/routing-kit/issues/147"))
+    @Test("Catchall catches empty path", .bug("https://github.com/vapor/routing-kit/issues/147"))
     func emptyCatchall() throws {
         var b = TrieRouterBuilder<Int>()
         b.register(1, at: [.catchall])


### PR DESCRIPTION
Closes https://github.com/vapor/routing-kit/issues/147

If we're using `.catchall` we should match `[]` too.