### PR TITLE
Disallow homonymous parameters in partial

### DIFF
--- a/Sources/RoutingKit/TrieRouter/TrieRouterBuilder.swift
+++ b/Sources/RoutingKit/TrieRouter/TrieRouterBuilder.swift
@@ -119,9 +119,7 @@ public struct TrieRouterBuilder<Output: Sendable>: RouterBuilder {
             )
             return node.copyWith(wildcard: newWildcard)
         case .partialParameter(let template, let components, let parameters):
-            guard parameters.count == Set(parameters).count else {
-                preconditionFailure("Partial \":\(template)\" contains multiple same-named parameters")
-            }
+           precondition(parameters.count == Set(parameters).count, #"Partial ":\#(template)" contains multiple parameters with the same name"#)
             var partials = node.partials ?? []
             let child = partials.first(where: { $0.template == template })?.node ?? Node()
             let updatedChild = insertRoute(node: child, path: path.dropFirst(), output: output)

--- a/Sources/RoutingKit/TrieRouter/TrieRouterBuilder.swift
+++ b/Sources/RoutingKit/TrieRouter/TrieRouterBuilder.swift
@@ -119,6 +119,9 @@ public struct TrieRouterBuilder<Output: Sendable>: RouterBuilder {
             )
             return node.copyWith(wildcard: newWildcard)
         case .partialParameter(let template, let components, let parameters):
+            guard parameters.count == Set(parameters).count else {
+                preconditionFailure("Partial \":\(template)\" contains multiple same-named parameters")
+            }
             var partials = node.partials ?? []
             let child = partials.first(where: { $0.template == template })?.node ?? Node()
             let updatedChild = insertRoute(node: child, path: path.dropFirst(), output: output)

--- a/Sources/RoutingKit/TrieRouter/TrieRouterBuilder.swift
+++ b/Sources/RoutingKit/TrieRouter/TrieRouterBuilder.swift
@@ -119,7 +119,9 @@ public struct TrieRouterBuilder<Output: Sendable>: RouterBuilder {
             )
             return node.copyWith(wildcard: newWildcard)
         case .partialParameter(let template, let components, let parameters):
-           precondition(parameters.count == Set(parameters).count, #"Partial ":\#(template)" contains multiple parameters with the same name"#)
+            precondition(
+                parameters.count == Set(parameters).count, #"Partial ":\#(template)" contains multiple parameters with the same name"#
+            )
             var partials = node.partials ?? []
             let child = partials.first(where: { $0.template == template })?.node ?? Node()
             let updatedChild = insertRoute(node: child, path: path.dropFirst(), output: output)

--- a/Tests/RoutingKitTests/RouterTests.swift
+++ b/Tests/RoutingKitTests/RouterTests.swift
@@ -354,6 +354,14 @@ struct RouterTests {
                 builder.register(20, at: ["p", ":{open"])
             }
         }
+
+        @Test("Same name partial parameter fails")
+        func sameNamePartialParameter() async throws {
+            await #expect(processExitsWith: .failure) {
+                var b = TrieRouterBuilder<Int>()
+                b.register(1, at: [":{param}.{param}"])
+            }
+        }
     #endif
 
     @Test func testPartialGreedyAnchors() throws {


### PR DESCRIPTION
This disallows partials to be registered with multiple parameters with the same name by failing when registering the route